### PR TITLE
load in batches of 100; pause 3s per 100 ops

### DIFF
--- a/redeemer/delegator.py
+++ b/redeemer/delegator.py
@@ -30,7 +30,7 @@ class Delegator(object):
     def __init__(
             self,
             steem=None,
-            limit=1000,
+            limit=100,
             logger=logging.NullHandler,
             deplorables=None):
         if steem is None:
@@ -163,7 +163,7 @@ class Delegator(object):
         if not dry_run:
             result = tx.broadcast()
             self.logger.info('transaction broadcast. result: %s', result)
-            pause = 3 * len(deltas) / 1000 # rate limit: max 1000 ops per 3s
+            pause = 3 * len(deltas) / 100 # rate limit: max 100 ops per 3s
             time.sleep(pause) # avoid steem#1973 & drastic bandwidth adjustments
 
         return (deltas, last_idx)


### PR DESCRIPTION
The last run caused the reserve ratio to go as low as 2x, and the bandwidth adjustment was too much even for @steem. This PR will slow the process down 10x and limit batch size to 100 instead of 1000.

![image](https://user-images.githubusercontent.com/5168676/40142081-48e13112-591d-11e8-8a33-b8dfe7055b2b.png)
